### PR TITLE
feat: allow configurable scope for DirChanged event

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Defaults
   load_on_setup = true,
   -- Force a run when using an unsupported executable
   force_run = false,
+  -- Scopes to update env vars on (e.g. { "global", "tabpage", "window" })
+  cd_scope = { "global" },
 }
 ```
 

--- a/doc/mise.nvim.txt
+++ b/doc/mise.nvim.txt
@@ -49,6 +49,8 @@ Defaults
       load_on_setup = true,
       -- Force a run when using an unsupported executable
       force_run = false,
+      -- Scopes to update env vars on (e.g. { "global", "tabpage", "window" })
+      cd_scope = { "global" },
     }
 <
 

--- a/lua/mise/init.lua
+++ b/lua/mise/init.lua
@@ -10,6 +10,7 @@ local defaults = {
 	unset_vars = true,
 	load_on_setup = true,
 	force_run = false,
+	cd_scope = { "global" },
 }
 
 ---@type MiseConfig
@@ -105,7 +106,7 @@ function Mise.setup(opt)
 		group = group,
 		desc = "Run command to load env vars",
 		callback = function()
-			if vim.v.event.scope == "global" then
+			if vim.tbl_contains(options.cd_scope, vim.v.event.scope) then
 				dir_changed()
 			end
 		end,


### PR DESCRIPTION
## Summary
Adds a `cd_scope` configuration option to control which `DirChanged` event scopes trigger environment variable updates.

## Motivation
Plugins like `Snacks.picker.projects()` often change the working directory at the tab scope (using `tcd`) rather than globally. Previously, `mise.nvim` hardcoded the listener to only `global` scope, causing it to ignore these directory changes.

Additionally, if the tab-local directory (`tcd`) is set, a subsequent global `cd` to the same directory may not trigger the `DirChanged` event as expected, leaving the environment variables stale.

## Changes
- Added `cd_scope` to `MiseConfig` (defaults to `{ "global" }` for backward compatibility).
- Updated the `DirChanged` autocmd to check if `vim.v.event.scope` is present in the user's configured `cd_scope`.

## Usage
To enable `mise` updates for tab-local directory changes:

```lua
require("mise").setup({
  cd_scope = { "global", "tabpage" }
})
```
